### PR TITLE
Fixed missing dependency to LLVMTransformUtils

### DIFF
--- a/lib/Transforms/Obfuscation/LLVMBuild.txt
+++ b/lib/Transforms/Obfuscation/LLVMBuild.txt
@@ -20,4 +20,4 @@ type = Library
 name = Obfuscation
 parent = Transforms
 library_name = Obfuscation
-
+required_libraries = Analysis Core Support TransformUtils


### PR DESCRIPTION
Build fails on RHEL with unsatisfied requirement on TransformUtils.

Build log excrept:
```
../../lib/libLLVMObfuscation.a(Flattening.cpp.o): In function `(anonymous namespace)::Flattening::runOnFunction(llvm::Function&)':
Flattening.cpp:(.text._ZN12_GLOBAL__N_110Flattening13runOnFunctionERN4llvm8FunctionE+0xd9): undefined reference to `llvm::createLowerSwitchPass()'
collect2: error: ld returned 1 exit status
make[2]: *** [lib/libLTO.so.4.0.1] Error 1
make[1]: *** [tools/lto/CMakeFiles/LTO.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
../../lib/libLLVMObfuscation.a(Flattening.cpp.o): In function `(anonymous namespace)::Flattening::runOnFunction(llvm::Function&)':
Flattening.cpp:(.text._ZN12_GLOBAL__N_110Flattening13runOnFunctionERN4llvm8FunctionE+0xd9): undefined reference to `llvm::createLowerSwitchPass()'
collect2: error: ld returned 1 exit status
make[2]: *** [bin/llvm-lto] Error 1
make[1]: *** [tools/llvm-lto/CMakeFiles/llvm-lto.dir/all] Error 2
```

Function `llvm::createLowerSwitchPass` is defined at TransformUtils and it should be added as a dependency after LLVMBuild.txt scan by cmake. PR includes this fix.