### PR TITLE
fix lli bug in llvm-4.0

### DIFF
--- a/include/llvm/ExecutionEngine/Orc/OrcRemoteTargetClient.h
+++ b/include/llvm/ExecutionEngine/Orc/OrcRemoteTargetClient.h
@@ -687,7 +687,7 @@ private:
 
   uint32_t getTrampolineSize() const { return RemoteTrampolineSize; }
 
-  Expected<std::vector<char>> readMem(char *Dst, JITTargetAddress Src,
+  Expected<std::vector<uint8_t>> readMem(char *Dst, JITTargetAddress Src,
                                       uint64_t Size) {
     // Check for an 'out-of-band' error, e.g. from an MM destructor.
     if (ExistingError)


### PR DESCRIPTION
when build lli, readMem return value type(Expected<std::vector<uint8_t>>) mismatch its sig(Expected<std::vector\<char\>>),cause a compiler error

> D:/msys64/home/DELL/obfuscator/include/llvm/ExecutionEngine/Orc/OrcRemoteTargetClient.h:696:26: error: could not convert '((llvm::orc::remote::OrcRemoteTargetClient<ChannelT>*)this)->callB<llvm::orc::remote::OrcRemoteTargetRPCAPI::ReadMem>(Src, Size)' from 'Expected<vector<unsigned char,allocator<unsigned char>>>' to 'Expected<vector<char,allocator<char>>>'
>      return callB<ReadMem>(Src, Size);

it can be checked by gcc-8.2.0(8.0.x and above) but not in old gcc version(used to be a bug for gcc?).

affect llvm4.0-llvm5.0

llvm bug ref:https://bugzilla.redhat.com/show_bug.cgi?id=1540620